### PR TITLE
chore: typo in fn name concurrency_get

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl VipsApp {
     }
 
     /// get the number of worker threads that vips is operating
-    pub fn concurency_get(&self) -> i32 {
+    pub fn concurrency_get(&self) -> i32 {
         unsafe {
             bindings::vips_concurrency_get()
         }


### PR DESCRIPTION
This is just a typo fix in a function name. 