### PR TITLE
Add wrapper for VipsImage `vips_image_get_orientation`

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -319,6 +319,10 @@ impl VipsImage {
         }
     }
 
+    pub fn get_orientation(&self) -> i32 {
+        unsafe { bindings::vips_image_get_orientation(self.ctx) }
+    }
+
     pub fn get_interpretation(&self) -> Result<Interpretation> {
         unsafe {
             let res = bindings::vips_image_get_interpretation(self.ctx);


### PR DESCRIPTION
I'm working on a project that requires getting an image's exif orientation data, and saw that `get_orientation` was not yet implemented in `image.rs`.