### PR TITLE
fix: Thumbnail options should have import_profile and export_profile optional instead empty string

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -17884,9 +17884,9 @@ pub struct ThumbnailImageOptions {
     /// default: false
     pub linear: bool,
     /// import_profile: `String` -> Fallback import profile
-    pub import_profile: String,
+    pub import_profile: Option<String>,
     /// export_profile: `String` -> Fallback export profile
-    pub export_profile: String,
+    pub export_profile: Option<String>,
     /// intent: `Intent` -> Rendering intent
     ///  `Perceptual` -> VIPS_INTENT_PERCEPTUAL = 0
     ///  `Relative` -> VIPS_INTENT_RELATIVE = 1 [DEFAULT]
@@ -17911,8 +17911,8 @@ impl std::default::Default for ThumbnailImageOptions {
             no_rotate: false,
             crop: Interesting::None,
             linear: false,
-            import_profile: String::new(),
-            export_profile: String::new(),
+            import_profile: None,
+            export_profile: None,
             intent: Intent::Relative,
             fail_on: FailOn::None,
         }
@@ -17954,12 +17954,16 @@ pub fn thumbnail_image_with_opts(
         let linear_in: i32 = if thumbnail_image_options.linear { 1 } else { 0 };
         let linear_in_name = utils::new_c_string("linear")?;
 
-        let import_profile_in: CString =
-            utils::new_c_string(&thumbnail_image_options.import_profile)?;
+        let import_profile_in = thumbnail_image_options.import_profile.clone()
+            .map(|v| utils::new_c_string(&v).ok())
+            .unwrap_or(None)
+            .map(|v| v.as_ptr());
         let import_profile_in_name = utils::new_c_string("import-profile")?;
 
-        let export_profile_in: CString =
-            utils::new_c_string(&thumbnail_image_options.export_profile)?;
+        let export_profile_in = thumbnail_image_options.export_profile.clone()
+            .map(|v| utils::new_c_string(&v).ok())
+            .unwrap_or(None)
+            .map(|v| v.as_ptr());
         let export_profile_in_name = utils::new_c_string("export-profile")?;
 
         let intent_in: i32 = thumbnail_image_options.intent as i32;
@@ -17983,9 +17987,10 @@ pub fn thumbnail_image_with_opts(
             linear_in_name.as_ptr(),
             linear_in,
             import_profile_in_name.as_ptr(),
-            import_profile_in.as_ptr(),
+            import_profile_in.unwrap_or(std::ptr::null_mut()),
             export_profile_in_name.as_ptr(),
-            export_profile_in.as_ptr(),
+            export_profile_in.unwrap_or(std::ptr::null_mut()),
+            NULL,
             intent_in_name.as_ptr(),
             intent_in,
             fail_on_in_name.as_ptr(),


### PR DESCRIPTION
Thumbnail generation is not working for now, because we are passing empty string for import_profile. You can skip this value and thumbnail generation work. This use now Option for `import_profile` and `export_profile`.

# Example code to reproduce

```rust
use std::path::PathBuf;

use libvips::{VipsApp, VipsImage, ops};
use anyhow::{Result, Context};

fn main() -> Result<()> {
  let app = VipsApp::new("example", false)?;
  app.concurrency_set(4);

  let image = VipsImage::new_from_file("...").with_context(|| "Could not load image")?;
  let thumbnail = ops::thumbnail_image_with_opts(&image, 100, &ops::ThumbnailImageOptions {
    height: 100,
    crop: ops::Interesting::Attention,
    ..ops::ThumbnailImageOptions::default()
  });

  match thumbnail {
    Ok(image) => {
      //optional parameters
      let options = ops::JpegsaveOptions {
        q: 90,
        background: vec![255.0],
        strip: true,
        optimize_coding: true,
        optimize_scans: true,
        interlace: true,
        ..ops::JpegsaveOptions::default()
      };

      ops::jpegsave_with_opts(&image, "output.jpeg",  &options)?;
    },

    Err(error) => {
      println!("error: {}", app.error_buffer().unwrap())
    }
  }

  Ok(())
}

```