### PR TITLE
chore: update readme vips version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # libvips-rust-bindings
-Rust bindings for libvips. Generated from `version 8.14.5`.
+Rust bindings for libvips. Generated from `version 8.15.1`.
 
 This is a safe wrapper for [libvips](https://libvips.github.io/libvips/) C library. It is made on top of the C API and based on the introspection API results.
 


### PR DESCRIPTION
# Description
Per the latest release:
https://github.com/olxgroup-oss/libvips-rust-bindings/releases/tag/v1.7.0

The bindings have been updated to v8.15.1. Since libvips is not forward compatible, it should be noted that the version has changed.