### PR TITLE
feat: Add safe method for constructing image from memory

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -135,7 +135,7 @@ impl VipsImage {
         }
     }
 
-    pub fn new_from_memory(
+    pub unsafe fn new_from_memory(
         buffer: &[u8],
         width: i32,
         height: i32,
@@ -163,6 +163,37 @@ impl VipsImage {
             }
         }
     }
+
+    pub fn new_from_memory_copy(
+        buffer: &[u8],
+        width: i32,
+        height: i32,
+        bands: i32,
+        format: BandFormat,
+    ) -> Result<VipsImage> {
+        unsafe {
+            if let Some(format) = format.to_i32() {
+                let res = bindings::vips_image_new_from_memory_copy(
+                    buffer.as_ptr() as *const c_void,
+                    buffer.len() as u64,
+                    width,
+                    height,
+                    bands,
+                    format,
+                );
+                vips_image_result(
+                    res,
+                    Error::InitializationError("Could not initialise VipsImage from memory"),
+                )
+            } else {
+                Err(Error::InitializationError(
+                    "Invalid BandFormat. Please file a bug report, as this should never happen.",
+                ))
+            }
+        }
+    }
+
+
 
     pub fn image_new_matrix(width: i32, height: i32) -> Result<VipsImage> {
         unsafe {

--- a/src/image.rs
+++ b/src/image.rs
@@ -135,7 +135,9 @@ impl VipsImage {
         }
     }
 
-    pub unsafe fn new_from_memory(
+    /// This is the main type of vips. It represents an image and most operations will take one as input and output a new one.
+    /// In the moment this type is not thread safe. Be careful working within thread environments.
+    pub fn new_from_memory(
         buffer: &[u8],
         width: i32,
         height: i32,


### PR DESCRIPTION
`new_from_memory` is unsafe as vips Image will not take ownership of memory. I marked this function unsafe as it's easy to seg fault. new_from_memory_copy will copy memory but also take ownership.