### PR TITLE
fix: guard against null pointer in new_byte_array to prevent panic on Rust 1.87+

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,6 +86,16 @@ pub(crate) fn new_c_string(string: &str) -> Result<CString> {
 
 #[inline]
 pub(crate) unsafe fn new_byte_array(buf: *mut c_void, size: u64) -> Vec<u8> {
+    // Guard against null: when a *save_buffer C function fails it leaves buf as
+    // null but still returns a non-zero error code.  `utils::result` evaluates
+    // its `output` argument eagerly (standard Rust call-by-value semantics), so
+    // `new_byte_array` is called unconditionally before the error code is
+    // checked.  Without this guard that path calls
+    // `Vec::from_raw_parts(ptr::null_mut(), 0, 0)` which violates the
+    // `NonNull` precondition added in Rust 1.87 and panics at runtime.
+    if buf.is_null() {
+        return Vec::new();
+    }
     Vec::from_raw_parts(buf as *mut u8, size as usize, size as usize)
 }
 


### PR DESCRIPTION
## Problem

When any `*save_buffer` C function (e.g. `vips_webpsave_buffer`) **fails**, libvips sets the output buffer pointer to null and returns a non-zero status code. `utils::result` is called as:

```rust
utils::result(vips_op_response, utils::new_byte_array(buf_out, buf_out_size), Error::...)
```

Because Rust evaluates function arguments eagerly (call-by-value), `new_byte_array(null_ptr, 0)` is called **unconditionally** before `utils::result` can check the return code.

`new_byte_array` calls `Vec::from_raw_parts(ptr as *mut u8, size, size)`. **Rust 1.87** added a runtime precondition check to `NonNull::new_unchecked` (used internally by `Vec::from_raw_parts`) that panics when given a null pointer:

```
thread 'tokimo-w-34' panicked at core/src/ptr/unique.rs:89:36:
unsafe precondition(s) violated: NonNull::new_unchecked requires that the pointer is non-null
```

Stack trace (abridged):
```
libvips::utils::new_byte_array           ← Vec::from_raw_parts(null, 0, 0) → panic
libvips::ops::webpsave_buffer_with_opts
my_crate::encode_image
```

## Root cause

This was latent undefined behaviour in all previous Rust versions; Rust 1.87 made it detectable at runtime.

All `*save_buffer` / `*save_buffer_with_opts` functions in `ops.rs` share the same pattern and are affected.

## Fix

Add a null guard in `new_byte_array`:

```rust
if buf.is_null() {
    return Vec::new();
}
```

When the C function fails, `new_byte_array` returns an empty `Vec` (which is immediately discarded), and `utils::result` sees the non-zero status code and returns `Err(error)` as intended.

## Verification

Reproduced the panic in a real application using libvips 8.15.1 + Rust 1.87.0. After applying this patch the error is handled gracefully with no panic.