### PR TITLE
fix: guard against null pointer in new_byte_array to prevent UB/panic on Rust 1.87+

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,6 +86,16 @@ pub(crate) fn new_c_string(string: &str) -> Result<CString> {
 
 #[inline]
 pub(crate) unsafe fn new_byte_array(buf: *mut c_void, size: u64) -> Vec<u8> {
+    // Guard against null: when a *save_buffer C function fails it leaves buf as
+    // null but still returns a non-zero error code.  `utils::result` evaluates
+    // its `output` argument eagerly (standard Rust call-by-value semantics), so
+    // `new_byte_array` is called unconditionally before the error code is
+    // checked.  Without this guard that path calls
+    // `Vec::from_raw_parts(ptr::null_mut(), 0, 0)` which violates the
+    // `NonNull` precondition added in Rust 1.87 and panics at runtime.
+    if buf.is_null() {
+        return Vec::new();
+    }
     Vec::from_raw_parts(buf as *mut u8, size as usize, size as usize)
 }
 


### PR DESCRIPTION
## Problem

Fixes #148

All 16 `*save_buffer` / `*save_buffer_with_opts` call sites in `ops.rs` follow this pattern:

```rust
utils::result(
    vips_op_response,
    utils::new_byte_array(buffer_out, buffer_buf_size),  // eager evaluation!
    Error::WebpsaveBufferError,
)
```

Rust evaluates function arguments **eagerly** (call-by-value), so `new_byte_array(buffer_out, size)` is called **unconditionally** — even when the C function failed and `buffer_out` is still `null`.

`new_byte_array` then calls `Vec::from_raw_parts(null, 0, 0)`, which is **undefined behavior**. Starting with Rust 1.87, `NonNull::new_unchecked` (used internally by `Vec::from_raw_parts`) has a runtime precondition check that catches this:

```
thread panicked at core/src/ptr/unique.rs:89:36:
unsafe precondition(s) violated: NonNull::new_unchecked requires that the pointer is non-null
thread caused non-unwinding panic. aborting.
```

### Common trigger: version mismatch

This is easily triggered when the system libvips is older than the version the crate was generated against. For example, crate 1.7.3 was generated for libvips 8.17.3, but if the system has 8.15.1, `webpsave_buffer_with_opts` passes unknown GObject properties (`target-size`, `smart-deblock`, `passes` — added in 8.16), causing:

```
webpsave_buffer: no property named 'target-size'
```

The C function returns `-1`, leaves `buffer_out = null`, and triggers the UB.

## Fix

Add a null guard in `new_byte_array`: if `buf` is null, return an empty `Vec`. The caller (`utils::result`) then sees the non-zero C return code and returns `Err(error)`, so the empty Vec is immediately dropped without being used.

This is the minimal correct fix that:
- Lives in hand-maintained `utils.rs` (not auto-generated `ops.rs`)
- Protects **all** 16 `*save_buffer` call sites at once
- Converts a hard panic/UB into a graceful `Err`
- Has zero overhead on the success path

## Verification

Tested on:
- **System**: Ubuntu 24.04, libvips 8.15.1, Rust 1.87.0 (also verified with 1.94.0)
- **Reproduction**: `ops::webpsave_buffer_with_opts(&img, &WebpsaveBufferOptions::default())` with crate generated for 8.17.3 on system with 8.15.1

| Scenario | Without fix | With fix |
|----------|-------------|----------|
| `webpsave_buffer_with_opts` on 8.15.1 | **PANIC** (abort, exit 134) | `Err(WebpsaveBufferError)` |
| `webpsave_buffer` (no extra opts) | OK | OK (no change) |

Full stack trace (without fix):
```
NonNull::new_unchecked → Unique::new_unchecked → RawVecInner::from_raw_parts_in
→ Vec::from_raw_parts → libvips::utils::new_byte_array → ops::webpsave_buffer_with_opts
```

## Long-term considerations

This PR is a targeted soundness fix. Issue #148 also documents:
- **Version compatibility**: `build.rs` should use `pkg-config` to check system libvips version
- **Generator improvement**: The `ops.rs` template in `generator/build.rs` could be updated to defer `new_byte_array` evaluation (avoiding the need for the null guard entirely)

These are larger changes best addressed separately.