### PR TITLE
fix: defer output construction in utils::result to prevent UB on C function failure

### DIFF
--- a/generator/build.rs
+++ b/generator/build.rs
@@ -218,7 +218,7 @@ impl Operation {
         unsafe {{
             {}
             let vips_op_response = bindings::vips_{}({}, NULL);
-            utils::result(vips_op_response, {}, Error::{}Error)
+            utils::result(vips_op_response, || {}, Error::{}Error)
         }}
         "#,
             self.get_variables(with_optional),

--- a/src/image.rs
+++ b/src/image.rs
@@ -237,7 +237,7 @@ impl VipsImage {
             let result = bindings::vips_image_wio_input(self.ctx);
             utils::result(
                 result,
-                (),
+                || (),
                 Error::OperationError("Error on vips image_wio_input"),
             )
         }
@@ -395,7 +395,7 @@ impl VipsImage {
             let res = bindings::vips_image_write(self.ctx, out);
             utils::result(
                 res,
-                VipsImage { ctx: out },
+                || VipsImage { ctx: out },
                 Error::IOError("Cannot write input to output"),
             )
         }
@@ -404,21 +404,21 @@ impl VipsImage {
     pub fn image_pio_input(&mut self) -> Result<()> {
         unsafe {
             let res = bindings::vips_image_pio_input(self.ctx);
-            utils::result(res, (), Error::IOError("Cannot read image"))
+            utils::result(res, || (), Error::IOError("Cannot read image"))
         }
     }
 
     pub fn image_pio_output(&mut self) -> Result<()> {
         unsafe {
             let res = bindings::vips_image_pio_output(self.ctx);
-            utils::result(res, (), Error::IOError("Cannot write image"))
+            utils::result(res, || (), Error::IOError("Cannot write image"))
         }
     }
 
     pub fn image_inplace(&self) -> Result<()> {
         unsafe {
             let res = bindings::vips_image_inplace(self.ctx);
-            utils::result(res, (), Error::IOError("Cannot cannot be modified inplace"))
+            utils::result(res, || (), Error::IOError("Cannot cannot be modified inplace"))
         }
     }
 
@@ -426,14 +426,14 @@ impl VipsImage {
         unsafe {
             let file_c_str = utils::new_c_string(filename)?;
             let res = bindings::vips_image_write_to_file(self.ctx, file_c_str.as_ptr(), NULL);
-            utils::result(res, (), Error::IOError("Cannot write to file"))
+            utils::result(res, || (), Error::IOError("Cannot write to file"))
         }
     }
 
     pub fn image_write_prepare(&self) -> Result<()> {
         unsafe {
             let res = bindings::vips_image_write_prepare(self.ctx);
-            utils::result(res, (), Error::IOError("Cannot prepare file to write"))
+            utils::result(res, || (), Error::IOError("Cannot prepare file to write"))
         }
     }
 
@@ -451,7 +451,7 @@ impl VipsImage {
             );
             utils::result(
                 res,
-                utils::new_byte_array(buffer_out, buffer_buf_size),
+                || utils::new_byte_array(buffer_out, buffer_buf_size),
                 Error::IOError("Cannot write content to buffer"),
             )
         }
@@ -477,7 +477,7 @@ impl VipsImage {
             if format_enum.is_some() {
                 utils::result(
                     res,
-                    (out_bands, format_enum.unwrap()),
+                    || (out_bands, format_enum.unwrap()),
                     Error::IOError("Could not predict image format"),
                 )
             } else {
@@ -492,7 +492,7 @@ impl VipsImage {
             let res = bindings::vips_image_decode(self.ctx, &mut out);
             utils::result(
                 res,
-                VipsImage { ctx: out },
+                || VipsImage { ctx: out },
                 Error::IOError("Cannot decode image"),
             )
         }
@@ -504,7 +504,7 @@ impl VipsImage {
             let res = bindings::vips_image_encode(self.ctx, &mut out, coding as i32);
             utils::result(
                 res,
-                VipsImage { ctx: out },
+                || VipsImage { ctx: out },
                 Error::IOError("Cannot encode image"),
             )
         }
@@ -612,7 +612,7 @@ impl VipsSource {
             let result = bindings::vips_source_unminimise(self.ctx);
             utils::result(
                 result,
-                (),
+                || (),
                 Error::OperationError("Error on vips unminimise"),
             )
         }
@@ -623,7 +623,7 @@ impl VipsSource {
             let result = bindings::vips_source_decode(self.ctx);
             utils::result(
                 result,
-                (),
+                || (),
                 Error::OperationError("Error on vips decode"),
             )
         }

--- a/src/manual.rs
+++ b/src/manual.rs
@@ -20,7 +20,7 @@ pub fn linear(inp: &VipsImage, a: &mut[f64], b: &mut[f64]) -> Result<VipsImage> 
             bindings::vips_linear(inp_in, &mut out_out, a_in, b_in, b.len() as i32, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LinearError,
         )
     }
@@ -75,7 +75,7 @@ pub fn linear_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LinearError,
         )
     }
@@ -104,7 +104,7 @@ pub fn getpoint(inp: &VipsImage, x: i32, y: i32) -> Result<Vec<f64>> {
         );
         utils::result(
             vips_op_response,
-            utils::new_double_array(out_array, out_array_size.try_into().unwrap()),
+            || utils::new_double_array(out_array, out_array_size.try_into().unwrap()),
             Error::GetpointError,
         )
     }
@@ -125,7 +125,7 @@ pub fn case(index: &VipsImage, cases: &mut [VipsImage], n: i32) -> Result<VipsIm
         let vips_op_response = bindings::vips_case(index_in, cases_in, &mut out_out, n, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CaseError,
         )
     }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -774,7 +774,7 @@ pub fn system(cmd_format: &str) -> Result<()> {
         let cmd_format_in: CString = utils::new_c_string(cmd_format)?;
 
         let vips_op_response = bindings::vips_system(cmd_format_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::SystemError)
+        utils::result(vips_op_response, || (), Error::SystemError)
     }
 }
 
@@ -843,7 +843,7 @@ pub fn system_with_opts(cmd_format: &str, system_options: &SystemOptions) -> Res
             in_format_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::SystemError)
+        utils::result(vips_op_response, || (), Error::SystemError)
     }
 }
 
@@ -860,7 +860,7 @@ pub fn add(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_add(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::AddError,
         )
     }
@@ -879,7 +879,7 @@ pub fn minpair(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_minpair(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MinpairError,
         )
     }
@@ -898,7 +898,7 @@ pub fn maxpair(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_maxpair(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaxpairError,
         )
     }
@@ -917,7 +917,7 @@ pub fn subtract(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_subtract(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SubtractError,
         )
     }
@@ -936,7 +936,7 @@ pub fn multiply(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_multiply(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MultiplyError,
         )
     }
@@ -955,7 +955,7 @@ pub fn divide(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_divide(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::DivideError,
         )
     }
@@ -993,7 +993,7 @@ pub fn relational(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RelationalError,
         )
     }
@@ -1012,7 +1012,7 @@ pub fn remainder(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_remainder(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RemainderError,
         )
     }
@@ -1049,7 +1049,7 @@ pub fn boolean(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BooleanError,
         )
     }
@@ -1080,7 +1080,7 @@ pub fn math_2(left: &VipsImage, right: &VipsImage, math_2: OperationMath2) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Math2Error,
         )
     }
@@ -1113,7 +1113,7 @@ pub fn complex_2(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Complex2Error,
         )
     }
@@ -1132,7 +1132,7 @@ pub fn complexform(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_complexform(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ComplexformError,
         )
     }
@@ -1149,7 +1149,7 @@ pub fn clamp(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_clamp(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ClampError,
         )
     }
@@ -1201,7 +1201,7 @@ pub fn clamp_with_opts(inp: &VipsImage, clamp_options: &ClampOptions) -> Result<
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ClampError,
         )
     }
@@ -1218,7 +1218,7 @@ pub fn invert(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_invert(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::InvertError,
         )
     }
@@ -1255,7 +1255,7 @@ pub fn math(inp: &VipsImage, math: OperationMath) -> Result<VipsImage> {
             bindings::vips_math(inp_in, &mut out_out, math_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MathError,
         )
     }
@@ -1270,7 +1270,7 @@ pub fn abs(inp: &VipsImage) -> Result<VipsImage> {
         let mut out_out: *mut bindings::VipsImage = null_mut();
 
         let vips_op_response = bindings::vips_abs(inp_in, &mut out_out, NULL);
-        utils::result(vips_op_response, VipsImage { ctx: out_out }, Error::AbError)
+        utils::result(vips_op_response, || VipsImage { ctx: out_out }, Error::AbError)
     }
 }
 
@@ -1285,7 +1285,7 @@ pub fn sign(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_sign(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SignError,
         )
     }
@@ -1309,7 +1309,7 @@ pub fn round(inp: &VipsImage, round: OperationRound) -> Result<VipsImage> {
             bindings::vips_round(inp_in, &mut out_out, round_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RoundError,
         )
     }
@@ -1348,7 +1348,7 @@ pub fn relational_const(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RelationalConstError,
         )
     }
@@ -1368,7 +1368,7 @@ pub fn remainder_const(inp: &VipsImage, c: &mut [f64]) -> Result<VipsImage> {
             bindings::vips_remainder_const(inp_in, &mut out_out, c_in, c.len() as i32, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RemainderConstError,
         )
     }
@@ -1406,7 +1406,7 @@ pub fn boolean_const(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BooleanConstError,
         )
     }
@@ -1438,7 +1438,7 @@ pub fn math_2_const(inp: &VipsImage, math_2: OperationMath2, c: &mut [f64]) -> R
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Math2ConstError,
         )
     }
@@ -1462,7 +1462,7 @@ pub fn complex(inp: &VipsImage, cmplx: OperationComplex) -> Result<VipsImage> {
             bindings::vips_complex(inp_in, &mut out_out, cmplx_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ComplexError,
         )
     }
@@ -1485,7 +1485,7 @@ pub fn complexget(inp: &VipsImage, get: OperationComplexget) -> Result<VipsImage
             bindings::vips_complexget(inp_in, &mut out_out, get_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ComplexgetError,
         )
     }
@@ -1509,7 +1509,7 @@ pub fn sum(inp: &mut [VipsImage]) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_sum(inp_in.as_mut_ptr(), &mut out_out, inp_len, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SumError,
         )
     }
@@ -1524,7 +1524,7 @@ pub fn avg(inp: &VipsImage) -> Result<f64> {
         let mut out_out: f64 = f64::from(0);
 
         let vips_op_response = bindings::vips_avg(inp_in, &mut out_out, NULL);
-        utils::result(vips_op_response, out_out, Error::AvgError)
+        utils::result(vips_op_response, || out_out, Error::AvgError)
     }
 }
 
@@ -1537,7 +1537,7 @@ pub fn min(inp: &VipsImage) -> Result<f64> {
         let mut out_out: f64 = f64::from(0);
 
         let vips_op_response = bindings::vips_min(inp_in, &mut out_out, NULL);
-        utils::result(vips_op_response, out_out, Error::MinError)
+        utils::result(vips_op_response, || out_out, Error::MinError)
     }
 }
 
@@ -1621,7 +1621,7 @@ pub fn min_with_opts(inp: &VipsImage, min_options: &MinOptions) -> Result<f64> {
             y_array_in,
             NULL,
         );
-        utils::result(vips_op_response, out_out, Error::MinError)
+        utils::result(vips_op_response, || out_out, Error::MinError)
     }
 }
 
@@ -1634,7 +1634,7 @@ pub fn max(inp: &VipsImage) -> Result<f64> {
         let mut out_out: f64 = f64::from(0);
 
         let vips_op_response = bindings::vips_max(inp_in, &mut out_out, NULL);
-        utils::result(vips_op_response, out_out, Error::MaxError)
+        utils::result(vips_op_response, || out_out, Error::MaxError)
     }
 }
 
@@ -1718,7 +1718,7 @@ pub fn max_with_opts(inp: &VipsImage, max_options: &MaxOptions) -> Result<f64> {
             y_array_in,
             NULL,
         );
-        utils::result(vips_op_response, out_out, Error::MaxError)
+        utils::result(vips_op_response, || out_out, Error::MaxError)
     }
 }
 
@@ -1731,7 +1731,7 @@ pub fn deviate(inp: &VipsImage) -> Result<f64> {
         let mut out_out: f64 = f64::from(0);
 
         let vips_op_response = bindings::vips_deviate(inp_in, &mut out_out, NULL);
-        utils::result(vips_op_response, out_out, Error::DeviateError)
+        utils::result(vips_op_response, || out_out, Error::DeviateError)
     }
 }
 
@@ -1746,7 +1746,7 @@ pub fn stats(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_stats(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::StatError,
         )
     }
@@ -1763,7 +1763,7 @@ pub fn hist_find(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hist_find(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistFindError,
         )
     }
@@ -1804,7 +1804,7 @@ pub fn hist_find_with_opts(
             bindings::vips_hist_find(inp_in, &mut out_out, band_in_name.as_ptr(), band_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistFindError,
         )
     }
@@ -1821,7 +1821,7 @@ pub fn hist_find_ndim(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hist_find_ndim(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistFindNdimError,
         )
     }
@@ -1867,7 +1867,7 @@ pub fn hist_find_ndim_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistFindNdimError,
         )
     }
@@ -1887,7 +1887,7 @@ pub fn hist_find_indexed(inp: &VipsImage, index: &VipsImage) -> Result<VipsImage
             bindings::vips_hist_find_indexed(inp_in, index_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistFindIndexedError,
         )
     }
@@ -1940,7 +1940,7 @@ pub fn hist_find_indexed_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistFindIndexedError,
         )
     }
@@ -1957,7 +1957,7 @@ pub fn hough_line(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hough_line(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HoughLineError,
         )
     }
@@ -2012,7 +2012,7 @@ pub fn hough_line_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HoughLineError,
         )
     }
@@ -2029,7 +2029,7 @@ pub fn hough_circle(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hough_circle(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HoughCircleError,
         )
     }
@@ -2093,7 +2093,7 @@ pub fn hough_circle_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HoughCircleError,
         )
     }
@@ -2115,7 +2115,7 @@ pub fn project(inp: &VipsImage) -> Result<(VipsImage, VipsImage)> {
             bindings::vips_project(inp_in, &mut columns_out, &mut rows_out, NULL);
         utils::result(
             vips_op_response,
-            (VipsImage { ctx: columns_out }, VipsImage { ctx: rows_out }),
+            || (VipsImage { ctx: columns_out }, VipsImage { ctx: rows_out }),
             Error::ProjectError,
         )
     }
@@ -2137,7 +2137,7 @@ pub fn profile(inp: &VipsImage) -> Result<(VipsImage, VipsImage)> {
             bindings::vips_profile(inp_in, &mut columns_out, &mut rows_out, NULL);
         utils::result(
             vips_op_response,
-            (VipsImage { ctx: columns_out }, VipsImage { ctx: rows_out }),
+            || (VipsImage { ctx: columns_out }, VipsImage { ctx: rows_out }),
             Error::ProfileError,
         )
     }
@@ -2160,7 +2160,7 @@ pub fn measure(inp: &VipsImage, h: i32, v: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_measure(inp_in, &mut out_out, h_in, v_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MeasureError,
         )
     }
@@ -2243,7 +2243,7 @@ pub fn measure_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MeasureError,
         )
     }
@@ -2275,7 +2275,7 @@ pub fn find_trim(inp: &VipsImage) -> Result<(i32, i32, i32, i32)> {
         );
         utils::result(
             vips_op_response,
-            (left_out, top_out, width_out, height_out),
+            || (left_out, top_out, width_out, height_out),
             Error::FindTrimError,
         )
     }
@@ -2351,7 +2351,7 @@ pub fn find_trim_with_opts(
         );
         utils::result(
             vips_op_response,
-            (left_out, top_out, width_out, height_out),
+            || (left_out, top_out, width_out, height_out),
             Error::FindTrimError,
         )
     }
@@ -2368,7 +2368,7 @@ pub fn copy(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_copy(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CopyError,
         )
     }
@@ -2527,7 +2527,7 @@ pub fn copy_with_opts(inp: &VipsImage, copy_options: &CopyOptions) -> Result<Vip
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CopyError,
         )
     }
@@ -2544,7 +2544,7 @@ pub fn tilecache(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_tilecache(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TilecacheError,
         )
     }
@@ -2638,7 +2638,7 @@ pub fn tilecache_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TilecacheError,
         )
     }
@@ -2655,7 +2655,7 @@ pub fn linecache(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_linecache(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LinecacheError,
         )
     }
@@ -2731,7 +2731,7 @@ pub fn linecache_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LinecacheError,
         )
     }
@@ -2748,7 +2748,7 @@ pub fn sequential(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_sequential(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SequentialError,
         )
     }
@@ -2794,7 +2794,7 @@ pub fn sequential_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SequentialError,
         )
     }
@@ -2824,7 +2824,7 @@ pub fn embed(inp: &VipsImage, x: i32, y: i32, width: i32, height: i32) -> Result
             bindings::vips_embed(inp_in, &mut out_out, x_in, y_in, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::EmbedError,
         )
     }
@@ -2905,7 +2905,7 @@ pub fn embed_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::EmbedError,
         )
     }
@@ -2952,7 +2952,7 @@ pub fn gravity(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GravityError,
         )
     }
@@ -3038,7 +3038,7 @@ pub fn gravity_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GravityError,
         )
     }
@@ -3061,7 +3061,7 @@ pub fn flip(inp: &VipsImage, direction: Direction) -> Result<VipsImage> {
             bindings::vips_flip(inp_in, &mut out_out, direction_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FlipError,
         )
     }
@@ -3087,7 +3087,7 @@ pub fn insert(main: &VipsImage, sub: &VipsImage, x: i32, y: i32) -> Result<VipsI
             bindings::vips_insert(main_in, sub_in, &mut out_out, x_in, y_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::InsertError,
         )
     }
@@ -3157,7 +3157,7 @@ pub fn insert_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::InsertError,
         )
     }
@@ -3187,7 +3187,7 @@ pub fn join(in_1: &VipsImage, in_2: &VipsImage, direction: Direction) -> Result<
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::JoinError,
         )
     }
@@ -3274,7 +3274,7 @@ pub fn join_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::JoinError,
         )
     }
@@ -3299,7 +3299,7 @@ pub fn arrayjoin(inp: &mut [VipsImage]) -> Result<VipsImage> {
             bindings::vips_arrayjoin(inp_in.as_mut_ptr(), &mut out_out, inp_len, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ArrayjoinError,
         )
     }
@@ -3414,7 +3414,7 @@ pub fn arrayjoin_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ArrayjoinError,
         )
     }
@@ -3457,7 +3457,7 @@ pub fn extract_area(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ExtractAreaError,
         )
     }
@@ -3481,7 +3481,7 @@ pub fn smartcrop(input: &VipsImage, width: i32, height: i32) -> Result<VipsImage
             bindings::vips_smartcrop(input_in, &mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SmartcropError,
         )
     }
@@ -3575,7 +3575,7 @@ pub fn smartcrop_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SmartcropError,
         )
     }
@@ -3595,7 +3595,7 @@ pub fn extract_band(inp: &VipsImage, band: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_extract_band(inp_in, &mut out_out, band_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ExtractBandError,
         )
     }
@@ -3644,7 +3644,7 @@ pub fn extract_band_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ExtractBandError,
         )
     }
@@ -3669,7 +3669,7 @@ pub fn bandjoin(inp: &mut [VipsImage]) -> Result<VipsImage> {
             bindings::vips_bandjoin(inp_in.as_mut_ptr(), &mut out_out, inp_len, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandjoinError,
         )
     }
@@ -3689,7 +3689,7 @@ pub fn bandjoin_const(inp: &VipsImage, c: &mut [f64]) -> Result<VipsImage> {
             bindings::vips_bandjoin_const(inp_in, &mut out_out, c_in, c.len() as i32, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandjoinConstError,
         )
     }
@@ -3714,7 +3714,7 @@ pub fn bandrank(inp: &mut [VipsImage]) -> Result<VipsImage> {
             bindings::vips_bandrank(inp_in.as_mut_ptr(), &mut out_out, inp_len, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandrankError,
         )
     }
@@ -3768,7 +3768,7 @@ pub fn bandrank_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandrankError,
         )
     }
@@ -3785,7 +3785,7 @@ pub fn bandmean(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_bandmean(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandmeanError,
         )
     }
@@ -3811,7 +3811,7 @@ pub fn bandbool(inp: &VipsImage, boolean: OperationBoolean) -> Result<VipsImage>
             bindings::vips_bandbool(inp_in, &mut out_out, boolean_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandboolError,
         )
     }
@@ -3835,7 +3835,7 @@ pub fn replicate(inp: &VipsImage, across: i32, down: i32) -> Result<VipsImage> {
             bindings::vips_replicate(inp_in, &mut out_out, across_in, down_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ReplicateError,
         )
     }
@@ -3867,7 +3867,7 @@ pub fn cast(inp: &VipsImage, format: BandFormat) -> Result<VipsImage> {
             bindings::vips_cast(inp_in, &mut out_out, format_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CastError,
         )
     }
@@ -3927,7 +3927,7 @@ pub fn cast_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CastError,
         )
     }
@@ -3952,7 +3952,7 @@ pub fn rot(inp: &VipsImage, angle: Angle) -> Result<VipsImage> {
             bindings::vips_rot(inp_in, &mut out_out, angle_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RotError,
         )
     }
@@ -3969,7 +3969,7 @@ pub fn rot_45(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_rot45(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Rot45Error,
         )
     }
@@ -4015,7 +4015,7 @@ pub fn rot_45_with_opts(inp: &VipsImage, rot_45_options: &Rot45Options) -> Resul
             bindings::vips_rot45(inp_in, &mut out_out, angle_in_name.as_ptr(), angle_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Rot45Error,
         )
     }
@@ -4032,7 +4032,7 @@ pub fn autorot(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_autorot(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::AutorotError,
         )
     }
@@ -4088,7 +4088,7 @@ pub fn autorot_with_opts(inp: &VipsImage, autorot_options: &AutorotOptions) -> R
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::AutorotError,
         )
     }
@@ -4110,7 +4110,7 @@ pub fn ifthenelse(cond: &VipsImage, in_1: &VipsImage, in_2: &VipsImage) -> Resul
             bindings::vips_ifthenelse(cond_in, in_1_in, in_2_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IfthenelseError,
         )
     }
@@ -4162,7 +4162,7 @@ pub fn ifthenelse_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IfthenelseError,
         )
     }
@@ -4181,7 +4181,7 @@ pub fn recomb(inp: &VipsImage, m: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_recomb(inp_in, &mut out_out, m_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RecombError,
         )
     }
@@ -4198,7 +4198,7 @@ pub fn bandfold(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_bandfold(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandfoldError,
         )
     }
@@ -4244,7 +4244,7 @@ pub fn bandfold_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandfoldError,
         )
     }
@@ -4261,7 +4261,7 @@ pub fn bandunfold(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_bandunfold(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandunfoldError,
         )
     }
@@ -4307,7 +4307,7 @@ pub fn bandunfold_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BandunfoldError,
         )
     }
@@ -4324,7 +4324,7 @@ pub fn flatten(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_flatten(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FlattenError,
         )
     }
@@ -4377,7 +4377,7 @@ pub fn flatten_with_opts(inp: &VipsImage, flatten_options: &FlattenOptions) -> R
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FlattenError,
         )
     }
@@ -4394,7 +4394,7 @@ pub fn premultiply(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_premultiply(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PremultiplyError,
         )
     }
@@ -4440,7 +4440,7 @@ pub fn premultiply_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PremultiplyError,
         )
     }
@@ -4457,7 +4457,7 @@ pub fn unpremultiply(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_unpremultiply(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::UnpremultiplyError,
         )
     }
@@ -4512,7 +4512,7 @@ pub fn unpremultiply_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::UnpremultiplyError,
         )
     }
@@ -4545,7 +4545,7 @@ pub fn grid(inp: &VipsImage, tile_height: i32, across: i32, down: i32) -> Result
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GridError,
         )
     }
@@ -4562,7 +4562,7 @@ pub fn transpose_3d(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_transpose3d(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Transpose3DError,
         )
     }
@@ -4608,7 +4608,7 @@ pub fn transpose_3d_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Transpose3DError,
         )
     }
@@ -4625,7 +4625,7 @@ pub fn scale(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_scale(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ScaleError,
         )
     }
@@ -4677,7 +4677,7 @@ pub fn scale_with_opts(inp: &VipsImage, scale_options: &ScaleOptions) -> Result<
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ScaleError,
         )
     }
@@ -4694,7 +4694,7 @@ pub fn wrap(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_wrap(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WrapError,
         )
     }
@@ -4746,7 +4746,7 @@ pub fn wrap_with_opts(inp: &VipsImage, wrap_options: &WrapOptions) -> Result<Vip
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WrapError,
         )
     }
@@ -4769,7 +4769,7 @@ pub fn zoom(input: &VipsImage, xfac: i32, yfac: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_zoom(input_in, &mut out_out, xfac_in, yfac_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ZoomError,
         )
     }
@@ -4793,7 +4793,7 @@ pub fn subsample(input: &VipsImage, xfac: i32, yfac: i32) -> Result<VipsImage> {
             bindings::vips_subsample(input_in, &mut out_out, xfac_in, yfac_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SubsampleError,
         )
     }
@@ -4847,7 +4847,7 @@ pub fn subsample_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SubsampleError,
         )
     }
@@ -4864,7 +4864,7 @@ pub fn msb(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_msb(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MsbError,
         )
     }
@@ -4902,7 +4902,7 @@ pub fn msb_with_opts(inp: &VipsImage, msb_options: &MsbOptions) -> Result<VipsIm
             bindings::vips_msb(inp_in, &mut out_out, band_in_name.as_ptr(), band_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MsbError,
         )
     }
@@ -4919,7 +4919,7 @@ pub fn byteswap(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_byteswap(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ByteswapError,
         )
     }
@@ -4936,7 +4936,7 @@ pub fn falsecolour(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_falsecolour(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FalsecolourError,
         )
     }
@@ -4953,7 +4953,7 @@ pub fn gamma(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_gamma(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GammaError,
         )
     }
@@ -4996,7 +4996,7 @@ pub fn gamma_with_opts(inp: &VipsImage, gamma_options: &GammaOptions) -> Result<
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GammaError,
         )
     }
@@ -5029,7 +5029,7 @@ pub fn composite(inp: &mut [VipsImage], mode: &mut [i32]) -> Result<VipsImage> {
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CompositeError,
         )
     }
@@ -5139,7 +5139,7 @@ pub fn composite_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CompositeError,
         )
     }
@@ -5192,7 +5192,7 @@ pub fn composite_2(base: &VipsImage, overlay: &VipsImage, mode: BlendMode) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Composite2Error,
         )
     }
@@ -5323,7 +5323,7 @@ pub fn composite_2_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Composite2Error,
         )
     }
@@ -5340,7 +5340,7 @@ pub fn addalpha(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_addalpha(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::AddalphaError,
         )
     }
@@ -5361,7 +5361,7 @@ pub fn black(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_black(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BlackError,
         )
     }
@@ -5409,7 +5409,7 @@ pub fn black_with_opts(width: i32, height: i32, black_options: &BlackOptions) ->
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BlackError,
         )
     }
@@ -5430,7 +5430,7 @@ pub fn gaussnoise(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_gaussnoise(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GaussnoiseError,
         )
     }
@@ -5500,7 +5500,7 @@ pub fn gaussnoise_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GaussnoiseError,
         )
     }
@@ -5521,7 +5521,7 @@ pub fn xyz(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_xyz(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::XyzError,
         )
     }
@@ -5587,7 +5587,7 @@ pub fn xyz_with_opts(width: i32, height: i32, xyz_options: &XyzOptions) -> Resul
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::XyzError,
         )
     }
@@ -5608,7 +5608,7 @@ pub fn gaussmat(sigma: f64, min_ampl: f64) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_gaussmat(&mut out_out, sigma_in, min_ampl_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GaussmatError,
         )
     }
@@ -5672,7 +5672,7 @@ pub fn gaussmat_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GaussmatError,
         )
     }
@@ -5693,7 +5693,7 @@ pub fn logmat(sigma: f64, min_ampl: f64) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_logmat(&mut out_out, sigma_in, min_ampl_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LogmatError,
         )
     }
@@ -5757,7 +5757,7 @@ pub fn logmat_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LogmatError,
         )
     }
@@ -5774,7 +5774,7 @@ pub fn text(text: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_text(&mut out_out, text_in.as_ptr(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TextError,
         )
     }
@@ -5912,7 +5912,7 @@ pub fn text_with_opts(text: &str, text_options: &TextOptions) -> Result<VipsImag
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TextError,
         )
     }
@@ -5946,7 +5946,7 @@ pub fn sdf(width: i32, height: i32, shape: SdfShape) -> Result<VipsImage> {
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SdfError,
         )
     }
@@ -6034,7 +6034,7 @@ pub fn sdf_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SdfError,
         )
     }
@@ -6055,7 +6055,7 @@ pub fn eye(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_eye(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::EyeError,
         )
     }
@@ -6112,7 +6112,7 @@ pub fn eye_with_opts(width: i32, height: i32, eye_options: &EyeOptions) -> Resul
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::EyeError,
         )
     }
@@ -6133,7 +6133,7 @@ pub fn grey(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_grey(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GreyError,
         )
     }
@@ -6179,7 +6179,7 @@ pub fn grey_with_opts(width: i32, height: i32, grey_options: &GreyOptions) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GreyError,
         )
     }
@@ -6200,7 +6200,7 @@ pub fn zone(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_zone(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ZoneError,
         )
     }
@@ -6246,7 +6246,7 @@ pub fn zone_with_opts(width: i32, height: i32, zone_options: &ZoneOptions) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ZoneError,
         )
     }
@@ -6267,7 +6267,7 @@ pub fn sines(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_sines(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SineError,
         )
     }
@@ -6333,7 +6333,7 @@ pub fn sines_with_opts(width: i32, height: i32, sines_options: &SineOptions) -> 
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SineError,
         )
     }
@@ -6358,7 +6358,7 @@ pub fn mask_ideal(width: i32, height: i32, frequency_cutoff: f64) -> Result<Vips
             bindings::vips_mask_ideal(&mut out_out, width_in, height_in, frequency_cutoff_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskIdealError,
         )
     }
@@ -6442,7 +6442,7 @@ pub fn mask_ideal_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskIdealError,
         )
     }
@@ -6481,7 +6481,7 @@ pub fn mask_ideal_ring(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskIdealRingError,
         )
     }
@@ -6574,7 +6574,7 @@ pub fn mask_ideal_ring_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskIdealRingError,
         )
     }
@@ -6618,7 +6618,7 @@ pub fn mask_ideal_band(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskIdealBandError,
         )
     }
@@ -6716,7 +6716,7 @@ pub fn mask_ideal_band_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskIdealBandError,
         )
     }
@@ -6760,7 +6760,7 @@ pub fn mask_butterworth(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskButterworthError,
         )
     }
@@ -6862,7 +6862,7 @@ pub fn mask_butterworth_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskButterworthError,
         )
     }
@@ -6911,7 +6911,7 @@ pub fn mask_butterworth_ring(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskButterworthRingError,
         )
     }
@@ -7026,7 +7026,7 @@ pub fn mask_butterworth_ring_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskButterworthRingError,
         )
     }
@@ -7080,7 +7080,7 @@ pub fn mask_butterworth_band(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskButterworthBandError,
         )
     }
@@ -7200,7 +7200,7 @@ pub fn mask_butterworth_band_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskButterworthBandError,
         )
     }
@@ -7239,7 +7239,7 @@ pub fn mask_gaussian(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskGaussianError,
         )
     }
@@ -7328,7 +7328,7 @@ pub fn mask_gaussian_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskGaussianError,
         )
     }
@@ -7372,7 +7372,7 @@ pub fn mask_gaussian_ring(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskGaussianRingError,
         )
     }
@@ -7482,7 +7482,7 @@ pub fn mask_gaussian_ring_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskGaussianRingError,
         )
     }
@@ -7531,7 +7531,7 @@ pub fn mask_gaussian_band(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskGaussianBandError,
         )
     }
@@ -7646,7 +7646,7 @@ pub fn mask_gaussian_band_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskGaussianBandError,
         )
     }
@@ -7676,7 +7676,7 @@ pub fn mask_fractal(width: i32, height: i32, fractal_dimension: f64) -> Result<V
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskFractalError,
         )
     }
@@ -7760,7 +7760,7 @@ pub fn mask_fractal_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaskFractalError,
         )
     }
@@ -7777,7 +7777,7 @@ pub fn buildlut(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_buildlut(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::BuildlutError,
         )
     }
@@ -7794,7 +7794,7 @@ pub fn invertlut(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_invertlut(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::InvertlutError,
         )
     }
@@ -7835,7 +7835,7 @@ pub fn invertlut_with_opts(
             bindings::vips_invertlut(inp_in, &mut out_out, size_in_name.as_ptr(), size_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::InvertlutError,
         )
     }
@@ -7851,7 +7851,7 @@ pub fn tonelut() -> Result<VipsImage> {
         let vips_op_response = bindings::vips_tonelut(&mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TonelutError,
         )
     }
@@ -7973,7 +7973,7 @@ pub fn tonelut_with_opts(tonelut_options: &TonelutOptions) -> Result<VipsImage> 
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TonelutError,
         )
     }
@@ -7989,7 +7989,7 @@ pub fn identity() -> Result<VipsImage> {
         let vips_op_response = bindings::vips_identity(&mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IdentityError,
         )
     }
@@ -8048,7 +8048,7 @@ pub fn identity_with_opts(identity_options: &IdentityOptions) -> Result<VipsImag
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IdentityError,
         )
     }
@@ -8078,7 +8078,7 @@ pub fn fractsurf(width: i32, height: i32, fractal_dimension: f64) -> Result<Vips
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FractsurfError,
         )
     }
@@ -8099,7 +8099,7 @@ pub fn worley(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_worley(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WorleyError,
         )
     }
@@ -8160,7 +8160,7 @@ pub fn worley_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WorleyError,
         )
     }
@@ -8181,7 +8181,7 @@ pub fn perlin(width: i32, height: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_perlin(&mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PerlinError,
         )
     }
@@ -8251,7 +8251,7 @@ pub fn perlin_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PerlinError,
         )
     }
@@ -8276,7 +8276,7 @@ pub fn switch(tests: &mut [VipsImage]) -> Result<VipsImage> {
             bindings::vips_switch(tests_in.as_mut_ptr(), &mut out_out, tests_len, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SwitchError,
         )
     }
@@ -8293,7 +8293,7 @@ pub fn csvload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_csvload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CsvloadError,
         )
     }
@@ -8417,7 +8417,7 @@ pub fn csvload_with_opts(filename: &str, csvload_options: &CsvloadOptions) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CsvloadError,
         )
     }
@@ -8434,7 +8434,7 @@ pub fn csvload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_csvload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CsvloadSourceError,
         )
     }
@@ -8565,7 +8565,7 @@ pub fn csvload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CsvloadSourceError,
         )
     }
@@ -8582,7 +8582,7 @@ pub fn matrixload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_matrixload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MatrixloadError,
         )
     }
@@ -8675,7 +8675,7 @@ pub fn matrixload_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MatrixloadError,
         )
     }
@@ -8692,7 +8692,7 @@ pub fn matrixload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_matrixload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MatrixloadSourceError,
         )
     }
@@ -8793,7 +8793,7 @@ pub fn matrixload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MatrixloadSourceError,
         )
     }
@@ -8826,7 +8826,7 @@ pub fn rawload(filename: &str, width: i32, height: i32, bands: i32) -> Result<Vi
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RawloadError,
         )
     }
@@ -8992,7 +8992,7 @@ pub fn rawload_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RawloadError,
         )
     }
@@ -9009,7 +9009,7 @@ pub fn vipsload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_vipsload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::VipsloadError,
         )
     }
@@ -9099,7 +9099,7 @@ pub fn vipsload_with_opts(filename: &str, vipsload_options: &VipsloadOptions) ->
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::VipsloadError,
         )
     }
@@ -9116,7 +9116,7 @@ pub fn vipsload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_vipsload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::VipsloadSourceError,
         )
     }
@@ -9213,7 +9213,7 @@ pub fn vipsload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::VipsloadSourceError,
         )
     }
@@ -9230,7 +9230,7 @@ pub fn analyzeload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_analyzeload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::AnalyzeloadError,
         )
     }
@@ -9323,7 +9323,7 @@ pub fn analyzeload_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::AnalyzeloadError,
         )
     }
@@ -9340,7 +9340,7 @@ pub fn ppmload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_ppmload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PpmloadError,
         )
     }
@@ -9430,7 +9430,7 @@ pub fn ppmload_with_opts(filename: &str, ppmload_options: &PpmloadOptions) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PpmloadError,
         )
     }
@@ -9448,7 +9448,7 @@ pub fn ppmload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_ppmload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PpmloadBufferError,
         )
     }
@@ -9546,7 +9546,7 @@ pub fn ppmload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PpmloadBufferError,
         )
     }
@@ -9563,7 +9563,7 @@ pub fn ppmload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_ppmload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PpmloadSourceError,
         )
     }
@@ -9660,7 +9660,7 @@ pub fn ppmload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PpmloadSourceError,
         )
     }
@@ -9677,7 +9677,7 @@ pub fn radload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_radload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RadloadError,
         )
     }
@@ -9767,7 +9767,7 @@ pub fn radload_with_opts(filename: &str, radload_options: &RadloadOptions) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RadloadError,
         )
     }
@@ -9785,7 +9785,7 @@ pub fn radload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_radload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RadloadBufferError,
         )
     }
@@ -9883,7 +9883,7 @@ pub fn radload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RadloadBufferError,
         )
     }
@@ -9900,7 +9900,7 @@ pub fn radload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_radload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RadloadSourceError,
         )
     }
@@ -9997,7 +9997,7 @@ pub fn radload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RadloadSourceError,
         )
     }
@@ -10014,7 +10014,7 @@ pub fn svgload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_svgload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SvgloadError,
         )
     }
@@ -10148,7 +10148,7 @@ pub fn svgload_with_opts(filename: &str, svgload_options: &SvgloadOptions) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SvgloadError,
         )
     }
@@ -10166,7 +10166,7 @@ pub fn svgload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_svgload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SvgloadBufferError,
         )
     }
@@ -10316,7 +10316,7 @@ pub fn svgload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SvgloadBufferError,
         )
     }
@@ -10333,7 +10333,7 @@ pub fn gifload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_gifload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GifloadError,
         )
     }
@@ -10441,7 +10441,7 @@ pub fn gifload_with_opts(filename: &str, gifload_options: &GifloadOptions) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GifloadError,
         )
     }
@@ -10459,7 +10459,7 @@ pub fn gifload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_gifload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GifloadBufferError,
         )
     }
@@ -10575,7 +10575,7 @@ pub fn gifload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GifloadBufferError,
         )
     }
@@ -10592,7 +10592,7 @@ pub fn gifload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_gifload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GifloadSourceError,
         )
     }
@@ -10707,7 +10707,7 @@ pub fn gifload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GifloadSourceError,
         )
     }
@@ -10724,7 +10724,7 @@ pub fn pngload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_pngload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PngloadError,
         )
     }
@@ -10823,7 +10823,7 @@ pub fn pngload_with_opts(filename: &str, pngload_options: &PngloadOptions) -> Re
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PngloadError,
         )
     }
@@ -10841,7 +10841,7 @@ pub fn pngload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_pngload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PngloadBufferError,
         )
     }
@@ -10952,7 +10952,7 @@ pub fn pngload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PngloadBufferError,
         )
     }
@@ -10969,7 +10969,7 @@ pub fn pngload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_pngload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PngloadSourceError,
         )
     }
@@ -11079,7 +11079,7 @@ pub fn pngload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PngloadSourceError,
         )
     }
@@ -11096,7 +11096,7 @@ pub fn jpegload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_jpegload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::JpegloadError,
         )
     }
@@ -11213,7 +11213,7 @@ pub fn jpegload_with_opts(filename: &str, jpegload_options: &JpegloadOptions) ->
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::JpegloadError,
         )
     }
@@ -11231,7 +11231,7 @@ pub fn jpegload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_jpegload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::JpegloadBufferError,
         )
     }
@@ -11364,7 +11364,7 @@ pub fn jpegload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::JpegloadBufferError,
         )
     }
@@ -11381,7 +11381,7 @@ pub fn webpload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_webpload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WebploadError,
         )
     }
@@ -11498,7 +11498,7 @@ pub fn webpload_with_opts(filename: &str, webpload_options: &WebploadOptions) ->
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WebploadError,
         )
     }
@@ -11516,7 +11516,7 @@ pub fn webpload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_webpload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WebploadBufferError,
         )
     }
@@ -11641,7 +11641,7 @@ pub fn webpload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WebploadBufferError,
         )
     }
@@ -11658,7 +11658,7 @@ pub fn webpload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_webpload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WebploadSourceError,
         )
     }
@@ -11782,7 +11782,7 @@ pub fn webpload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::WebploadSourceError,
         )
     }
@@ -11799,7 +11799,7 @@ pub fn tiffload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_tiffload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TiffloadError,
         )
     }
@@ -11934,7 +11934,7 @@ pub fn tiffload_with_opts(filename: &str, tiffload_options: &TiffloadOptions) ->
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TiffloadError,
         )
     }
@@ -11952,7 +11952,7 @@ pub fn tiffload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_tiffload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TiffloadBufferError,
         )
     }
@@ -12103,7 +12103,7 @@ pub fn tiffload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TiffloadBufferError,
         )
     }
@@ -12120,7 +12120,7 @@ pub fn tiffload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_tiffload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TiffloadSourceError,
         )
     }
@@ -12270,7 +12270,7 @@ pub fn tiffload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::TiffloadSourceError,
         )
     }
@@ -12287,7 +12287,7 @@ pub fn heifload(filename: &str) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_heifload(filename_in.as_ptr(), &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HeifloadError,
         )
     }
@@ -12413,7 +12413,7 @@ pub fn heifload_with_opts(filename: &str, heifload_options: &HeifloadOptions) ->
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HeifloadError,
         )
     }
@@ -12431,7 +12431,7 @@ pub fn heifload_buffer(buffer: &[u8]) -> Result<VipsImage> {
             bindings::vips_heifload_buffer(buffer_in, buffer.len() as u64, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HeifloadBufferError,
         )
     }
@@ -12573,7 +12573,7 @@ pub fn heifload_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HeifloadBufferError,
         )
     }
@@ -12590,7 +12590,7 @@ pub fn heifload_source(source: &VipsSource) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_heifload_source(source_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HeifloadSourceError,
         )
     }
@@ -12731,7 +12731,7 @@ pub fn heifload_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HeifloadSourceError,
         )
     }
@@ -12747,7 +12747,7 @@ pub fn csvsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_csvsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::CsvsaveError)
+        utils::result(vips_op_response, || (), Error::CsvsaveError)
     }
 }
 
@@ -12832,7 +12832,7 @@ pub fn csvsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::CsvsaveError)
+        utils::result(vips_op_response, || (), Error::CsvsaveError)
     }
 }
 
@@ -12846,7 +12846,7 @@ pub fn csvsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_csvsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::CsvsaveTargetError)
+        utils::result(vips_op_response, || (), Error::CsvsaveTargetError)
     }
 }
 
@@ -12931,7 +12931,7 @@ pub fn csvsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::CsvsaveTargetError)
+        utils::result(vips_op_response, || (), Error::CsvsaveTargetError)
     }
 }
 
@@ -12945,7 +12945,7 @@ pub fn matrixsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_matrixsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::MatrixsaveError)
+        utils::result(vips_op_response, || (), Error::MatrixsaveError)
     }
 }
 
@@ -13022,7 +13022,7 @@ pub fn matrixsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::MatrixsaveError)
+        utils::result(vips_op_response, || (), Error::MatrixsaveError)
     }
 }
 
@@ -13036,7 +13036,7 @@ pub fn matrixsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_matrixsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::MatrixsaveTargetError)
+        utils::result(vips_op_response, || (), Error::MatrixsaveTargetError)
     }
 }
 
@@ -13113,7 +13113,7 @@ pub fn matrixsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::MatrixsaveTargetError)
+        utils::result(vips_op_response, || (), Error::MatrixsaveTargetError)
     }
 }
 
@@ -13125,7 +13125,7 @@ pub fn matrixprint(inp: &VipsImage) -> Result<()> {
         let inp_in: *mut bindings::VipsImage = inp.ctx;
 
         let vips_op_response = bindings::vips_matrixprint(inp_in, NULL);
-        utils::result(vips_op_response, (), Error::MatrixprintError)
+        utils::result(vips_op_response, || (), Error::MatrixprintError)
     }
 }
 
@@ -13198,7 +13198,7 @@ pub fn matrixprint_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::MatrixprintError)
+        utils::result(vips_op_response, || (), Error::MatrixprintError)
     }
 }
 
@@ -13212,7 +13212,7 @@ pub fn rawsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_rawsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::RawsaveError)
+        utils::result(vips_op_response, || (), Error::RawsaveError)
     }
 }
 
@@ -13289,7 +13289,7 @@ pub fn rawsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::RawsaveError)
+        utils::result(vips_op_response, || (), Error::RawsaveError)
     }
 }
 
@@ -13306,7 +13306,7 @@ pub fn rawsave_buffer(inp: &VipsImage) -> Result<Vec<u8>> {
             bindings::vips_rawsave_buffer(inp_in, &mut buffer_out, &mut buffer_buf_size, NULL);
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::RawsaveBufferError,
         )
     }
@@ -13387,7 +13387,7 @@ pub fn rawsave_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::RawsaveBufferError,
         )
     }
@@ -13403,7 +13403,7 @@ pub fn rawsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_rawsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::RawsaveTargetError)
+        utils::result(vips_op_response, || (), Error::RawsaveTargetError)
     }
 }
 
@@ -13480,7 +13480,7 @@ pub fn rawsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::RawsaveTargetError)
+        utils::result(vips_op_response, || (), Error::RawsaveTargetError)
     }
 }
 
@@ -13494,7 +13494,7 @@ pub fn vipssave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_vipssave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::VipssaveError)
+        utils::result(vips_op_response, || (), Error::VipssaveError)
     }
 }
 
@@ -13571,7 +13571,7 @@ pub fn vipssave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::VipssaveError)
+        utils::result(vips_op_response, || (), Error::VipssaveError)
     }
 }
 
@@ -13585,7 +13585,7 @@ pub fn vipssave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_vipssave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::VipssaveTargetError)
+        utils::result(vips_op_response, || (), Error::VipssaveTargetError)
     }
 }
 
@@ -13662,7 +13662,7 @@ pub fn vipssave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::VipssaveTargetError)
+        utils::result(vips_op_response, || (), Error::VipssaveTargetError)
     }
 }
 
@@ -13676,7 +13676,7 @@ pub fn ppmsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_ppmsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::PpmsaveError)
+        utils::result(vips_op_response, || (), Error::PpmsaveError)
     }
 }
 
@@ -13785,7 +13785,7 @@ pub fn ppmsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::PpmsaveError)
+        utils::result(vips_op_response, || (), Error::PpmsaveError)
     }
 }
 
@@ -13799,7 +13799,7 @@ pub fn ppmsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_ppmsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::PpmsaveTargetError)
+        utils::result(vips_op_response, || (), Error::PpmsaveTargetError)
     }
 }
 
@@ -13908,7 +13908,7 @@ pub fn ppmsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::PpmsaveTargetError)
+        utils::result(vips_op_response, || (), Error::PpmsaveTargetError)
     }
 }
 
@@ -13922,7 +13922,7 @@ pub fn radsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_radsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::RadsaveError)
+        utils::result(vips_op_response, || (), Error::RadsaveError)
     }
 }
 
@@ -13999,7 +13999,7 @@ pub fn radsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::RadsaveError)
+        utils::result(vips_op_response, || (), Error::RadsaveError)
     }
 }
 
@@ -14016,7 +14016,7 @@ pub fn radsave_buffer(inp: &VipsImage) -> Result<Vec<u8>> {
             bindings::vips_radsave_buffer(inp_in, &mut buffer_out, &mut buffer_buf_size, NULL);
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::RadsaveBufferError,
         )
     }
@@ -14097,7 +14097,7 @@ pub fn radsave_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::RadsaveBufferError,
         )
     }
@@ -14113,7 +14113,7 @@ pub fn radsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_radsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::RadsaveTargetError)
+        utils::result(vips_op_response, || (), Error::RadsaveTargetError)
     }
 }
 
@@ -14190,7 +14190,7 @@ pub fn radsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::RadsaveTargetError)
+        utils::result(vips_op_response, || (), Error::RadsaveTargetError)
     }
 }
 
@@ -14204,7 +14204,7 @@ pub fn gifsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_gifsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::GifsaveError)
+        utils::result(vips_op_response, || (), Error::GifsaveError)
     }
 }
 
@@ -14357,7 +14357,7 @@ pub fn gifsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::GifsaveError)
+        utils::result(vips_op_response, || (), Error::GifsaveError)
     }
 }
 
@@ -14374,7 +14374,7 @@ pub fn gifsave_buffer(inp: &VipsImage) -> Result<Vec<u8>> {
             bindings::vips_gifsave_buffer(inp_in, &mut buffer_out, &mut buffer_buf_size, NULL);
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::GifsaveBufferError,
         )
     }
@@ -14535,7 +14535,7 @@ pub fn gifsave_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::GifsaveBufferError,
         )
     }
@@ -14551,7 +14551,7 @@ pub fn gifsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_gifsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::GifsaveTargetError)
+        utils::result(vips_op_response, || (), Error::GifsaveTargetError)
     }
 }
 
@@ -14708,7 +14708,7 @@ pub fn gifsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::GifsaveTargetError)
+        utils::result(vips_op_response, || (), Error::GifsaveTargetError)
     }
 }
 
@@ -14722,7 +14722,7 @@ pub fn pngsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_pngsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::PngsaveError)
+        utils::result(vips_op_response, || (), Error::PngsaveError)
     }
 }
 
@@ -14876,7 +14876,7 @@ pub fn pngsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::PngsaveError)
+        utils::result(vips_op_response, || (), Error::PngsaveError)
     }
 }
 
@@ -14893,7 +14893,7 @@ pub fn pngsave_buffer(inp: &VipsImage) -> Result<Vec<u8>> {
             bindings::vips_pngsave_buffer(inp_in, &mut buffer_out, &mut buffer_buf_size, NULL);
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::PngsaveBufferError,
         )
     }
@@ -15055,7 +15055,7 @@ pub fn pngsave_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::PngsaveBufferError,
         )
     }
@@ -15071,7 +15071,7 @@ pub fn pngsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_pngsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::PngsaveTargetError)
+        utils::result(vips_op_response, || (), Error::PngsaveTargetError)
     }
 }
 
@@ -15229,7 +15229,7 @@ pub fn pngsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::PngsaveTargetError)
+        utils::result(vips_op_response, || (), Error::PngsaveTargetError)
     }
 }
 
@@ -15243,7 +15243,7 @@ pub fn jpegsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_jpegsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::JpegsaveError)
+        utils::result(vips_op_response, || (), Error::JpegsaveError)
     }
 }
 
@@ -15416,7 +15416,7 @@ pub fn jpegsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::JpegsaveError)
+        utils::result(vips_op_response, || (), Error::JpegsaveError)
     }
 }
 
@@ -15433,7 +15433,7 @@ pub fn jpegsave_buffer(inp: &VipsImage) -> Result<Vec<u8>> {
             bindings::vips_jpegsave_buffer(inp_in, &mut buffer_out, &mut buffer_buf_size, NULL);
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::JpegsaveBufferError,
         )
     }
@@ -15618,7 +15618,7 @@ pub fn jpegsave_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::JpegsaveBufferError,
         )
     }
@@ -15634,7 +15634,7 @@ pub fn jpegsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_jpegsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::JpegsaveTargetError)
+        utils::result(vips_op_response, || (), Error::JpegsaveTargetError)
     }
 }
 
@@ -15815,7 +15815,7 @@ pub fn jpegsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::JpegsaveTargetError)
+        utils::result(vips_op_response, || (), Error::JpegsaveTargetError)
     }
 }
 
@@ -15827,7 +15827,7 @@ pub fn jpegsave_mime(inp: &VipsImage) -> Result<()> {
         let inp_in: *mut bindings::VipsImage = inp.ctx;
 
         let vips_op_response = bindings::vips_jpegsave_mime(inp_in, NULL);
-        utils::result(vips_op_response, (), Error::JpegsaveMimeError)
+        utils::result(vips_op_response, || (), Error::JpegsaveMimeError)
     }
 }
 
@@ -16004,7 +16004,7 @@ pub fn jpegsave_mime_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::JpegsaveMimeError)
+        utils::result(vips_op_response, || (), Error::JpegsaveMimeError)
     }
 }
 
@@ -16018,7 +16018,7 @@ pub fn webpsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_webpsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::WebpsaveError)
+        utils::result(vips_op_response, || (), Error::WebpsaveError)
     }
 }
 
@@ -16231,7 +16231,7 @@ pub fn webpsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::WebpsaveError)
+        utils::result(vips_op_response, || (), Error::WebpsaveError)
     }
 }
 
@@ -16248,7 +16248,7 @@ pub fn webpsave_buffer(inp: &VipsImage) -> Result<Vec<u8>> {
             bindings::vips_webpsave_buffer(inp_in, &mut buffer_out, &mut buffer_buf_size, NULL);
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::WebpsaveBufferError,
         )
     }
@@ -16481,7 +16481,7 @@ pub fn webpsave_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::WebpsaveBufferError,
         )
     }
@@ -16497,7 +16497,7 @@ pub fn webpsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_webpsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::WebpsaveTargetError)
+        utils::result(vips_op_response, || (), Error::WebpsaveTargetError)
     }
 }
 
@@ -16726,7 +16726,7 @@ pub fn webpsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::WebpsaveTargetError)
+        utils::result(vips_op_response, || (), Error::WebpsaveTargetError)
     }
 }
 
@@ -16738,7 +16738,7 @@ pub fn webpsave_mime(inp: &VipsImage) -> Result<()> {
         let inp_in: *mut bindings::VipsImage = inp.ctx;
 
         let vips_op_response = bindings::vips_webpsave_mime(inp_in, NULL);
-        utils::result(vips_op_response, (), Error::WebpsaveMimeError)
+        utils::result(vips_op_response, || (), Error::WebpsaveMimeError)
     }
 }
 
@@ -16955,7 +16955,7 @@ pub fn webpsave_mime_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::WebpsaveMimeError)
+        utils::result(vips_op_response, || (), Error::WebpsaveMimeError)
     }
 }
 
@@ -16969,7 +16969,7 @@ pub fn tiffsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_tiffsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::TiffsaveError)
+        utils::result(vips_op_response, || (), Error::TiffsaveError)
     }
 }
 
@@ -17249,7 +17249,7 @@ pub fn tiffsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::TiffsaveError)
+        utils::result(vips_op_response, || (), Error::TiffsaveError)
     }
 }
 
@@ -17266,7 +17266,7 @@ pub fn tiffsave_buffer(inp: &VipsImage) -> Result<Vec<u8>> {
             bindings::vips_tiffsave_buffer(inp_in, &mut buffer_out, &mut buffer_buf_size, NULL);
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::TiffsaveBufferError,
         )
     }
@@ -17574,7 +17574,7 @@ pub fn tiffsave_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::TiffsaveBufferError,
         )
     }
@@ -17590,7 +17590,7 @@ pub fn tiffsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_tiffsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::TiffsaveTargetError)
+        utils::result(vips_op_response, || (), Error::TiffsaveTargetError)
     }
 }
 
@@ -17894,7 +17894,7 @@ pub fn tiffsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::TiffsaveTargetError)
+        utils::result(vips_op_response, || (), Error::TiffsaveTargetError)
     }
 }
 
@@ -17908,7 +17908,7 @@ pub fn heifsave(inp: &VipsImage, filename: &str) -> Result<()> {
         let filename_in: CString = utils::new_c_string(filename)?;
 
         let vips_op_response = bindings::vips_heifsave(inp_in, filename_in.as_ptr(), NULL);
-        utils::result(vips_op_response, (), Error::HeifsaveError)
+        utils::result(vips_op_response, || (), Error::HeifsaveError)
     }
 }
 
@@ -18060,7 +18060,7 @@ pub fn heifsave_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::HeifsaveError)
+        utils::result(vips_op_response, || (), Error::HeifsaveError)
     }
 }
 
@@ -18077,7 +18077,7 @@ pub fn heifsave_buffer(inp: &VipsImage) -> Result<Vec<u8>> {
             bindings::vips_heifsave_buffer(inp_in, &mut buffer_out, &mut buffer_buf_size, NULL);
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::HeifsaveBufferError,
         )
     }
@@ -18237,7 +18237,7 @@ pub fn heifsave_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            utils::new_byte_array(buffer_out, buffer_buf_size),
+            || utils::new_byte_array(buffer_out, buffer_buf_size),
             Error::HeifsaveBufferError,
         )
     }
@@ -18253,7 +18253,7 @@ pub fn heifsave_target(inp: &VipsImage, target: &VipsTarget) -> Result<()> {
         let target_in: *mut bindings::VipsTarget = target.ctx;
 
         let vips_op_response = bindings::vips_heifsave_target(inp_in, target_in, NULL);
-        utils::result(vips_op_response, (), Error::HeifsaveTargetError)
+        utils::result(vips_op_response, || (), Error::HeifsaveTargetError)
     }
 }
 
@@ -18409,7 +18409,7 @@ pub fn heifsave_target_with_opts(
             profile_in.as_ptr(),
             NULL,
         );
-        utils::result(vips_op_response, (), Error::HeifsaveTargetError)
+        utils::result(vips_op_response, || (), Error::HeifsaveTargetError)
     }
 }
 
@@ -18428,7 +18428,7 @@ pub fn thumbnail(filename: &str, width: i32) -> Result<VipsImage> {
             bindings::vips_thumbnail(filename_in.as_ptr(), &mut out_out, width_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ThumbnailError,
         )
     }
@@ -18569,7 +18569,7 @@ pub fn thumbnail_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ThumbnailError,
         )
     }
@@ -18595,7 +18595,7 @@ pub fn thumbnail_buffer(buffer: &[u8], width: i32) -> Result<VipsImage> {
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ThumbnailBufferError,
         )
     }
@@ -18756,7 +18756,7 @@ pub fn thumbnail_buffer_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ThumbnailBufferError,
         )
     }
@@ -18776,7 +18776,7 @@ pub fn thumbnail_image(inp: &VipsImage, width: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_thumbnail_image(inp_in, &mut out_out, width_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ThumbnailImageError,
         )
     }
@@ -18923,7 +18923,7 @@ pub fn thumbnail_image_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ThumbnailImageError,
         )
     }
@@ -18944,7 +18944,7 @@ pub fn thumbnail_source(source: &VipsSource, width: i32) -> Result<VipsImage> {
             bindings::vips_thumbnail_source(source_in, &mut out_out, width_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ThumbnailSourceError,
         )
     }
@@ -19104,7 +19104,7 @@ pub fn thumbnail_source_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ThumbnailSourceError,
         )
     }
@@ -19123,7 +19123,7 @@ pub fn mapim(inp: &VipsImage, index: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_mapim(inp_in, &mut out_out, index_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MapimError,
         )
     }
@@ -19205,7 +19205,7 @@ pub fn mapim_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MapimError,
         )
     }
@@ -19229,7 +19229,7 @@ pub fn shrink(inp: &VipsImage, hshrink: f64, vshrink: f64) -> Result<VipsImage> 
             bindings::vips_shrink(inp_in, &mut out_out, hshrink_in, vshrink_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ShrinkError,
         )
     }
@@ -19283,7 +19283,7 @@ pub fn shrink_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ShrinkError,
         )
     }
@@ -19303,7 +19303,7 @@ pub fn shrinkh(inp: &VipsImage, hshrink: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_shrinkh(inp_in, &mut out_out, hshrink_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ShrinkhError,
         )
     }
@@ -19352,7 +19352,7 @@ pub fn shrinkh_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ShrinkhError,
         )
     }
@@ -19372,7 +19372,7 @@ pub fn shrinkv(inp: &VipsImage, vshrink: i32) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_shrinkv(inp_in, &mut out_out, vshrink_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ShrinkvError,
         )
     }
@@ -19421,7 +19421,7 @@ pub fn shrinkv_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ShrinkvError,
         )
     }
@@ -19441,7 +19441,7 @@ pub fn reduceh(inp: &VipsImage, hshrink: f64) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_reduceh(inp_in, &mut out_out, hshrink_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ReducehError,
         )
     }
@@ -19509,7 +19509,7 @@ pub fn reduceh_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ReducehError,
         )
     }
@@ -19529,7 +19529,7 @@ pub fn reducev(inp: &VipsImage, vshrink: f64) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_reducev(inp_in, &mut out_out, vshrink_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ReducevError,
         )
     }
@@ -19597,7 +19597,7 @@ pub fn reducev_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ReducevError,
         )
     }
@@ -19621,7 +19621,7 @@ pub fn reduce(inp: &VipsImage, hshrink: f64, vshrink: f64) -> Result<VipsImage> 
             bindings::vips_reduce(inp_in, &mut out_out, hshrink_in, vshrink_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ReduceError,
         )
     }
@@ -19694,7 +19694,7 @@ pub fn reduce_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ReduceError,
         )
     }
@@ -19713,7 +19713,7 @@ pub fn quadratic(inp: &VipsImage, coeff: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_quadratic(inp_in, &mut out_out, coeff_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::QuadraticError,
         )
     }
@@ -19762,7 +19762,7 @@ pub fn quadratic_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::QuadraticError,
         )
     }
@@ -19792,7 +19792,7 @@ pub fn affine(inp: &VipsImage, a: f64, b: f64, c: f64, d: f64) -> Result<VipsIma
             bindings::vips_affine(inp_in, &mut out_out, a_in, b_in, c_in, d_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::AffineError,
         )
     }
@@ -19936,7 +19936,7 @@ pub fn affine_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::AffineError,
         )
     }
@@ -19953,7 +19953,7 @@ pub fn similarity(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_similarity(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SimilarityError,
         )
     }
@@ -20062,7 +20062,7 @@ pub fn similarity_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SimilarityError,
         )
     }
@@ -20082,7 +20082,7 @@ pub fn rotate(inp: &VipsImage, angle: f64) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_rotate(inp_in, &mut out_out, angle_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RotateError,
         )
     }
@@ -20178,7 +20178,7 @@ pub fn rotate_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RotateError,
         )
     }
@@ -20198,7 +20198,7 @@ pub fn resize(inp: &VipsImage, scale: f64) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_resize(inp_in, &mut out_out, scale_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ResizeError,
         )
     }
@@ -20275,7 +20275,7 @@ pub fn resize_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ResizeError,
         )
     }
@@ -20316,7 +20316,7 @@ pub fn colourspace(inp: &VipsImage, space: Interpretation) -> Result<VipsImage> 
             bindings::vips_colourspace(inp_in, &mut out_out, space_in.try_into().unwrap(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ColourspaceError,
         )
     }
@@ -20407,7 +20407,7 @@ pub fn colourspace_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ColourspaceError,
         )
     }
@@ -20424,7 +20424,7 @@ pub fn lab_2xyz(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_Lab2XYZ(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Lab2XyzError,
         )
     }
@@ -20460,7 +20460,7 @@ pub fn lab_2xyz_with_opts(inp: &VipsImage, lab_2xyz_options: &Lab2XyzOptions) ->
             bindings::vips_Lab2XYZ(inp_in, &mut out_out, temp_in_name.as_ptr(), temp_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Lab2XyzError,
         )
     }
@@ -20477,7 +20477,7 @@ pub fn xyz2_lab(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_XYZ2Lab(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Xyz2LabError,
         )
     }
@@ -20516,7 +20516,7 @@ pub fn xyz2_lab_with_opts(
             bindings::vips_XYZ2Lab(inp_in, &mut out_out, temp_in_name.as_ptr(), temp_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Xyz2LabError,
         )
     }
@@ -20533,7 +20533,7 @@ pub fn lab_2l_ch(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_Lab2LCh(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Lab2LChError,
         )
     }
@@ -20550,7 +20550,7 @@ pub fn l_ch_2_lab(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_LCh2Lab(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LCh2LabError,
         )
     }
@@ -20567,7 +20567,7 @@ pub fn l_ch_2cmc(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_LCh2CMC(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LCh2CmcError,
         )
     }
@@ -20584,7 +20584,7 @@ pub fn cmc2l_ch(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_CMC2LCh(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Cmc2LChError,
         )
     }
@@ -20601,7 +20601,7 @@ pub fn xyz2_yxy(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_XYZ2Yxy(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Xyz2YxyError,
         )
     }
@@ -20618,7 +20618,7 @@ pub fn yxy_2xyz(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_Yxy2XYZ(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Yxy2XyzError,
         )
     }
@@ -20635,7 +20635,7 @@ pub fn sc_rgb2xyz(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_scRGB2XYZ(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ScRgb2XyzError,
         )
     }
@@ -20652,7 +20652,7 @@ pub fn xyz_2sc_rgb(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_XYZ2scRGB(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Xyz2ScRgbError,
         )
     }
@@ -20669,7 +20669,7 @@ pub fn lab_q2_lab(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_LabQ2Lab(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LabQ2LabError,
         )
     }
@@ -20686,7 +20686,7 @@ pub fn lab_2_lab_q(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_Lab2LabQ(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Lab2LabQError,
         )
     }
@@ -20703,7 +20703,7 @@ pub fn lab_q2_lab_s(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_LabQ2LabS(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LabQ2LabSError,
         )
     }
@@ -20720,7 +20720,7 @@ pub fn lab_s2_lab_q(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_LabS2LabQ(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LabS2LabQError,
         )
     }
@@ -20737,7 +20737,7 @@ pub fn lab_s2_lab(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_LabS2Lab(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LabS2LabError,
         )
     }
@@ -20754,7 +20754,7 @@ pub fn lab_2_lab_s(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_Lab2LabS(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Lab2LabSError,
         )
     }
@@ -20771,7 +20771,7 @@ pub fn rad_2float(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_rad2float(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Rad2FloatError,
         )
     }
@@ -20788,7 +20788,7 @@ pub fn float_2rad(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_float2rad(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Float2RadError,
         )
     }
@@ -20805,7 +20805,7 @@ pub fn lab_q_2s_rgb(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_LabQ2sRGB(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::LabQ2SRgbError,
         )
     }
@@ -20822,7 +20822,7 @@ pub fn s_rgb_2sc_rgb(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_sRGB2scRGB(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SRgb2ScRgbError,
         )
     }
@@ -20839,7 +20839,7 @@ pub fn sc_rgb2bw(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_scRGB2BW(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ScRgb2BwError,
         )
     }
@@ -20880,7 +20880,7 @@ pub fn sc_rgb2bw_with_opts(
             bindings::vips_scRGB2BW(inp_in, &mut out_out, depth_in_name.as_ptr(), depth_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ScRgb2BwError,
         )
     }
@@ -20897,7 +20897,7 @@ pub fn s_rgb2hsv(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_sRGB2HSV(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SRgb2HsvError,
         )
     }
@@ -20914,7 +20914,7 @@ pub fn hsv_2s_rgb(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_HSV2sRGB(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Hsv2SRgbError,
         )
     }
@@ -20931,7 +20931,7 @@ pub fn sc_rgb_2s_rgb(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_scRGB2sRGB(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ScRgb2SRgbError,
         )
     }
@@ -20972,7 +20972,7 @@ pub fn sc_rgb_2s_rgb_with_opts(
             bindings::vips_scRGB2sRGB(inp_in, &mut out_out, depth_in_name.as_ptr(), depth_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ScRgb2SRgbError,
         )
     }
@@ -20989,7 +20989,7 @@ pub fn icc_import(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_icc_import(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IccImportError,
         )
     }
@@ -21081,7 +21081,7 @@ pub fn icc_import_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IccImportError,
         )
     }
@@ -21098,7 +21098,7 @@ pub fn icc_export(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_icc_export(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IccExportError,
         )
     }
@@ -21190,7 +21190,7 @@ pub fn icc_export_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IccExportError,
         )
     }
@@ -21210,7 +21210,7 @@ pub fn icc_transform(inp: &VipsImage, output_profile: &str) -> Result<VipsImage>
             bindings::vips_icc_transform(inp_in, &mut out_out, output_profile_in.as_ptr(), NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IccTransformError,
         )
     }
@@ -21315,7 +21315,7 @@ pub fn icc_transform_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::IccTransformError,
         )
     }
@@ -21334,7 +21334,7 @@ pub fn d_e76(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_dE76(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::DE76Error,
         )
     }
@@ -21353,7 +21353,7 @@ pub fn d_e00(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_dE00(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::DE00Error,
         )
     }
@@ -21372,7 +21372,7 @@ pub fn d_ecmc(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_dECMC(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::DEcmcError,
         )
     }
@@ -21389,7 +21389,7 @@ pub fn cmyk2xyz(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_CMYK2XYZ(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Cmyk2XyzError,
         )
     }
@@ -21406,7 +21406,7 @@ pub fn xyz2cmyk(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_XYZ2CMYK(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Xyz2CmykError,
         )
     }
@@ -21424,7 +21424,7 @@ pub fn profile_load(name: &str) -> Result<Vec<u8>> {
             bindings::vips_profile_load(name_in.as_ptr(), &mut profile_out, NULL);
         utils::result(
             vips_op_response,
-            VipsBlob { ctx: profile_out }.into(),
+            || VipsBlob { ctx: profile_out }.into(),
             Error::ProfileLoadError,
         )
     }
@@ -21443,7 +21443,7 @@ pub fn maplut(inp: &VipsImage, lut: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_maplut(inp_in, &mut out_out, lut_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaplutError,
         )
     }
@@ -21493,7 +21493,7 @@ pub fn maplut_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MaplutError,
         )
     }
@@ -21511,7 +21511,7 @@ pub fn percent(inp: &VipsImage, percent: f64) -> Result<i32> {
         let mut threshold_out: i32 = i32::from(0);
 
         let vips_op_response = bindings::vips_percent(inp_in, percent_in, &mut threshold_out, NULL);
-        utils::result(vips_op_response, threshold_out, Error::PercentError)
+        utils::result(vips_op_response, || threshold_out, Error::PercentError)
     }
 }
 
@@ -21533,7 +21533,7 @@ pub fn stdif(inp: &VipsImage, width: i32, height: i32) -> Result<VipsImage> {
             bindings::vips_stdif(inp_in, &mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::StdifError,
         )
     }
@@ -21616,7 +21616,7 @@ pub fn stdif_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::StdifError,
         )
     }
@@ -21633,7 +21633,7 @@ pub fn hist_cum(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hist_cum(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistCumError,
         )
     }
@@ -21652,7 +21652,7 @@ pub fn hist_match(inp: &VipsImage, refp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hist_match(inp_in, refp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistMatchError,
         )
     }
@@ -21669,7 +21669,7 @@ pub fn hist_norm(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hist_norm(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistNormError,
         )
     }
@@ -21686,7 +21686,7 @@ pub fn hist_equal(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hist_equal(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistEqualError,
         )
     }
@@ -21727,7 +21727,7 @@ pub fn hist_equal_with_opts(
             bindings::vips_hist_equal(inp_in, &mut out_out, band_in_name.as_ptr(), band_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistEqualError,
         )
     }
@@ -21744,7 +21744,7 @@ pub fn hist_plot(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_hist_plot(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistPlotError,
         )
     }
@@ -21768,7 +21768,7 @@ pub fn hist_local(inp: &VipsImage, width: i32, height: i32) -> Result<VipsImage>
             bindings::vips_hist_local(inp_in, &mut out_out, width_in, height_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistLocalError,
         )
     }
@@ -21824,7 +21824,7 @@ pub fn hist_local_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::HistLocalError,
         )
     }
@@ -21841,7 +21841,7 @@ pub fn hist_ismonotonic(inp: &VipsImage) -> Result<bool> {
         let vips_op_response = bindings::vips_hist_ismonotonic(inp_in, &mut monotonic_out, NULL);
         utils::result(
             vips_op_response,
-            monotonic_out != 0,
+            || monotonic_out != 0,
             Error::HistIsmonotonicError,
         )
     }
@@ -21856,7 +21856,7 @@ pub fn hist_entropy(inp: &VipsImage) -> Result<f64> {
         let mut out_out: f64 = f64::from(0);
 
         let vips_op_response = bindings::vips_hist_entropy(inp_in, &mut out_out, NULL);
-        utils::result(vips_op_response, out_out, Error::HistEntropyError)
+        utils::result(vips_op_response, || out_out, Error::HistEntropyError)
     }
 }
 
@@ -21873,7 +21873,7 @@ pub fn conv(inp: &VipsImage, mask: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_conv(inp_in, &mut out_out, mask_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvError,
         )
     }
@@ -21944,7 +21944,7 @@ pub fn conv_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvError,
         )
     }
@@ -21963,7 +21963,7 @@ pub fn conva(inp: &VipsImage, mask: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_conva(inp_in, &mut out_out, mask_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvaError,
         )
     }
@@ -22022,7 +22022,7 @@ pub fn conva_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvaError,
         )
     }
@@ -22041,7 +22041,7 @@ pub fn convf(inp: &VipsImage, mask: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_convf(inp_in, &mut out_out, mask_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvfError,
         )
     }
@@ -22060,7 +22060,7 @@ pub fn convi(inp: &VipsImage, mask: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_convi(inp_in, &mut out_out, mask_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConviError,
         )
     }
@@ -22079,7 +22079,7 @@ pub fn compass(inp: &VipsImage, mask: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_compass(inp_in, &mut out_out, mask_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CompassError,
         )
     }
@@ -22188,7 +22188,7 @@ pub fn compass_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CompassError,
         )
     }
@@ -22207,7 +22207,7 @@ pub fn convsep(inp: &VipsImage, mask: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_convsep(inp_in, &mut out_out, mask_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvsepError,
         )
     }
@@ -22278,7 +22278,7 @@ pub fn convsep_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvsepError,
         )
     }
@@ -22297,7 +22297,7 @@ pub fn convasep(inp: &VipsImage, mask: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_convasep(inp_in, &mut out_out, mask_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvasepError,
         )
     }
@@ -22347,7 +22347,7 @@ pub fn convasep_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ConvasepError,
         )
     }
@@ -22366,7 +22366,7 @@ pub fn fastcor(inp: &VipsImage, refp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_fastcor(inp_in, refp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FastcorError,
         )
     }
@@ -22385,7 +22385,7 @@ pub fn spcor(inp: &VipsImage, refp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_spcor(inp_in, refp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SpcorError,
         )
     }
@@ -22402,7 +22402,7 @@ pub fn sharpen(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_sharpen(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SharpenError,
         )
     }
@@ -22490,7 +22490,7 @@ pub fn sharpen_with_opts(inp: &VipsImage, sharpen_options: &SharpenOptions) -> R
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SharpenError,
         )
     }
@@ -22510,7 +22510,7 @@ pub fn gaussblur(inp: &VipsImage, sigma: f64) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_gaussblur(inp_in, &mut out_out, sigma_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GaussblurError,
         )
     }
@@ -22573,7 +22573,7 @@ pub fn gaussblur_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GaussblurError,
         )
     }
@@ -22590,7 +22590,7 @@ pub fn sobel(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_sobel(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SobelError,
         )
     }
@@ -22607,7 +22607,7 @@ pub fn scharr(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_scharr(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::ScharrError,
         )
     }
@@ -22624,7 +22624,7 @@ pub fn prewitt(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_prewitt(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PrewittError,
         )
     }
@@ -22641,7 +22641,7 @@ pub fn canny(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_canny(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CannyError,
         )
     }
@@ -22696,7 +22696,7 @@ pub fn canny_with_opts(inp: &VipsImage, canny_options: &CannyOptions) -> Result<
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::CannyError,
         )
     }
@@ -22713,7 +22713,7 @@ pub fn fwfft(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_fwfft(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FwfftError,
         )
     }
@@ -22730,7 +22730,7 @@ pub fn invfft(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_invfft(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::InvfftError,
         )
     }
@@ -22766,7 +22766,7 @@ pub fn invfft_with_opts(inp: &VipsImage, invfft_options: &InvfftOptions) -> Resu
             bindings::vips_invfft(inp_in, &mut out_out, real_in_name.as_ptr(), real_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::InvfftError,
         )
     }
@@ -22785,7 +22785,7 @@ pub fn freqmult(inp: &VipsImage, mask: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_freqmult(inp_in, mask_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FreqmultError,
         )
     }
@@ -22802,7 +22802,7 @@ pub fn spectrum(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_spectrum(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::SpectrumError,
         )
     }
@@ -22821,7 +22821,7 @@ pub fn phasecor(inp: &VipsImage, in_2: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_phasecor(inp_in, in_2_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::PhasecorError,
         )
     }
@@ -22851,7 +22851,7 @@ pub fn morph(inp: &VipsImage, mask: &VipsImage, morph: OperationMorphology) -> R
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MorphError,
         )
     }
@@ -22878,7 +22878,7 @@ pub fn rank(inp: &VipsImage, width: i32, height: i32, index: i32) -> Result<Vips
             bindings::vips_rank(inp_in, &mut out_out, width_in, height_in, index_in, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RankError,
         )
     }
@@ -22903,7 +22903,7 @@ pub fn countlines(inp: &VipsImage, direction: Direction) -> Result<f64> {
             direction_in.try_into().unwrap(),
             NULL,
         );
-        utils::result(vips_op_response, nolines_out, Error::CountlineError)
+        utils::result(vips_op_response, || nolines_out, Error::CountlineError)
     }
 }
 
@@ -22918,7 +22918,7 @@ pub fn labelregions(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_labelregions(inp_in, &mut mask_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: mask_out },
+            || VipsImage { ctx: mask_out },
             Error::LabelregionError,
         )
     }
@@ -22964,7 +22964,7 @@ pub fn labelregions_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: mask_out },
+            || VipsImage { ctx: mask_out },
             Error::LabelregionError,
         )
     }
@@ -22981,7 +22981,7 @@ pub fn fill_nearest(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_fill_nearest(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FillNearestError,
         )
     }
@@ -23026,7 +23026,7 @@ pub fn fill_nearest_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::FillNearestError,
         )
     }
@@ -23070,7 +23070,7 @@ pub fn draw_rect(
             height_in,
             NULL,
         );
-        utils::result(vips_op_response, (), Error::DrawRectError)
+        utils::result(vips_op_response, || (), Error::DrawRectError)
     }
 }
 
@@ -23133,7 +23133,7 @@ pub fn draw_rect_with_opts(
             fill_in,
             NULL,
         );
-        utils::result(vips_op_response, (), Error::DrawRectError)
+        utils::result(vips_op_response, || (), Error::DrawRectError)
     }
 }
 
@@ -23169,7 +23169,7 @@ pub fn draw_mask(
             y_in,
             NULL,
         );
-        utils::result(vips_op_response, (), Error::DrawMaskError)
+        utils::result(vips_op_response, || (), Error::DrawMaskError)
     }
 }
 
@@ -23211,7 +23211,7 @@ pub fn draw_line(
             y_2_in,
             NULL,
         );
-        utils::result(vips_op_response, (), Error::DrawLineError)
+        utils::result(vips_op_response, || (), Error::DrawLineError)
     }
 }
 
@@ -23248,7 +23248,7 @@ pub fn draw_circle(
             radius_in,
             NULL,
         );
-        utils::result(vips_op_response, (), Error::DrawCircleError)
+        utils::result(vips_op_response, || (), Error::DrawCircleError)
     }
 }
 
@@ -23306,7 +23306,7 @@ pub fn draw_circle_with_opts(
             fill_in,
             NULL,
         );
-        utils::result(vips_op_response, (), Error::DrawCircleError)
+        utils::result(vips_op_response, || (), Error::DrawCircleError)
     }
 }
 
@@ -23327,7 +23327,7 @@ pub fn draw_flood(image: &VipsImage, ink: &mut [f64], x: i32, y: i32) -> Result<
 
         let vips_op_response =
             bindings::vips_draw_flood(image_in, ink_in, ink.len() as i32, x_in, y_in, NULL);
-        utils::result(vips_op_response, (), Error::DrawFloodError)
+        utils::result(vips_op_response, || (), Error::DrawFloodError)
     }
 }
 
@@ -23426,7 +23426,7 @@ pub fn draw_flood_with_opts(
             height_in,
             NULL,
         );
-        utils::result(vips_op_response, (), Error::DrawFloodError)
+        utils::result(vips_op_response, || (), Error::DrawFloodError)
     }
 }
 
@@ -23446,7 +23446,7 @@ pub fn draw_image(image: &VipsImage, sub: &VipsImage, x: i32, y: i32) -> Result<
         let y_in: i32 = y;
 
         let vips_op_response = bindings::vips_draw_image(image_in, sub_in, x_in, y_in, NULL);
-        utils::result(vips_op_response, (), Error::DrawImageError)
+        utils::result(vips_op_response, || (), Error::DrawImageError)
     }
 }
 
@@ -23502,7 +23502,7 @@ pub fn draw_image_with_opts(
             mode_in,
             NULL,
         );
-        utils::result(vips_op_response, (), Error::DrawImageError)
+        utils::result(vips_op_response, || (), Error::DrawImageError)
     }
 }
 
@@ -23527,7 +23527,7 @@ pub fn draw_smudge(image: &VipsImage, left: i32, top: i32, width: i32, height: i
 
         let vips_op_response =
             bindings::vips_draw_smudge(image_in, left_in, top_in, width_in, height_in, NULL);
-        utils::result(vips_op_response, (), Error::DrawSmudgeError)
+        utils::result(vips_op_response, || (), Error::DrawSmudgeError)
     }
 }
 
@@ -23569,7 +23569,7 @@ pub fn merge(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MergeError,
         )
     }
@@ -23636,7 +23636,7 @@ pub fn merge_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MergeError,
         )
     }
@@ -23690,7 +23690,7 @@ pub fn mosaic(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MosaicError,
         )
     }
@@ -23848,7 +23848,7 @@ pub fn mosaic_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MosaicError,
         )
     }
@@ -23922,7 +23922,7 @@ pub fn mosaic_1(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Mosaic1Error,
         )
     }
@@ -24054,7 +24054,7 @@ pub fn mosaic_1_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::Mosaic1Error,
         )
     }
@@ -24071,7 +24071,7 @@ pub fn matrixinvert(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_matrixinvert(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MatrixinvertError,
         )
     }
@@ -24090,7 +24090,7 @@ pub fn matrixmultiply(left: &VipsImage, right: &VipsImage) -> Result<VipsImage> 
         let vips_op_response = bindings::vips_matrixmultiply(left_in, right_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MatrixmultiplyError,
         )
     }
@@ -24157,7 +24157,7 @@ pub fn matches(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MatchError,
         )
     }
@@ -24273,7 +24273,7 @@ pub fn matches_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::MatchError,
         )
     }
@@ -24290,7 +24290,7 @@ pub fn globalbalance(inp: &VipsImage) -> Result<VipsImage> {
         let vips_op_response = bindings::vips_globalbalance(inp_in, &mut out_out, NULL);
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GlobalbalanceError,
         )
     }
@@ -24349,7 +24349,7 @@ pub fn globalbalance_with_opts(
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::GlobalbalanceError,
         )
     }
@@ -24376,7 +24376,7 @@ pub fn remosaic(inp: &VipsImage, old_str: &str, new_str: &str) -> Result<VipsIma
         );
         utils::result(
             vips_op_response,
-            VipsImage { ctx: out_out },
+            || VipsImage { ctx: out_out },
             Error::RemosaicError,
         )
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,10 +70,17 @@ impl From<&[VipsImage]> for VipsArrayImageWrapper {
     }
 }
 
+/// Checks the return code of a libvips C function and produces a `Result`.
+///
+/// `output` is a closure that constructs the success value **only** when the
+/// C function succeeded (`res == 0`).  This is critical for functions like
+/// `*save_buffer` where the output pointer is left null on failure —
+/// eagerly constructing a `Vec` via `from_raw_parts(null, …)` would be
+/// undefined behavior.
 #[inline]
-pub fn result<T>(res: i32, output: T, error: Error) -> Result<T> {
+pub fn result<T>(res: i32, output: impl FnOnce() -> T, error: Error) -> Result<T> {
     if res == 0 {
-        Ok(output)
+        Ok(output())
     } else {
         Err(error)
     }


### PR DESCRIPTION
Fixes #148

## Problem

All `*save_buffer` and other operation functions in `ops.rs` call:

```rust
utils::result(vips_op_response, utils::new_byte_array(buffer_out, size), Error::XxxError)
```

Rust evaluates function arguments eagerly — `new_byte_array(buffer_out, size)` runs **before** `result` checks the return code. When the C function fails (`res != 0`), output pointers are left as null, but `new_byte_array` already called `Vec::from_raw_parts(null, 0, 0)` — which is **undefined behavior**.

Starting with Rust 1.87, `NonNull::new_unchecked` has a runtime precondition check that catches this and **aborts the process**:

```
unsafe precondition(s) violated: NonNull::new_unchecked requires that the pointer is non-null
thread caused non-unwinding panic. aborting.
```

This affects all 16 `*save_buffer` sites. A common trigger is version mismatch — e.g., crate 1.7.3 (generated for libvips 8.17.3) passes unknown properties like `target-size` to system libvips 8.15.1, which rejects them and returns failure with null buffer.

## Fix

Change `utils::result` from eager to deferred evaluation:

```rust
// Before — output constructed unconditionally (UB when C fails)
pub fn result<T>(res: i32, output: T, error: Error) -> Result<T>

// After — output constructed only on success
pub fn result<T>(res: i32, output: impl FnOnce() -> T, error: Error) -> Result<T>
```

All call sites now pass a closure:
```rust
// Before
utils::result(vips_op_response, utils::new_byte_array(buf, size), Error::XxxError)

// After
utils::result(vips_op_response, || utils::new_byte_array(buf, size), Error::XxxError)
```

### Changes

| File | Change |
|------|--------|
| `src/utils.rs` | `result()` takes `impl FnOnce() -> T` instead of `T` |
| `generator/build.rs` | Template emits `\|\| {output}` closures |
| `src/ops.rs` | All 463 call sites wrapped in closures (mechanical transformation) |
| `src/image.rs` | 13 hand-written call sites updated |
| `src/manual.rs` | 4 hand-written call sites updated |

## Verification

System: Ubuntu 24.04, libvips 8.15.1, Rust 1.94.0

```rust
// Crate generated for 8.17.3, running on system with 8.15.1
let result = ops::webpsave_buffer_with_opts(&img, &WebpsaveBufferOptions::default());
```

| | Before | After |
|---|--------|-------|
| `webpsave_buffer_with_opts` (version mismatch) | **ABORT** (UB → NonNull panic) | `Err(WebpsaveBufferError)` ✅ |
| `webpsave_buffer` (no mismatch) | OK (163KB) | OK (163KB) ✅ |

## Notes

- The `impl FnOnce() -> T` change is source-breaking for any external code calling `utils::result` directly (they need to wrap the output in `\|\| ...`). However, `utils::result` is a low-level utility primarily used by generated code, and the breakage is trivially fixable.
- Issue #148 also describes a version compatibility concern (`build.rs` lacks `pkg-config` version checking). That is a separate concern and can be addressed in a follow-up.